### PR TITLE
feat: add document verification detail page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -5,6 +5,7 @@ import { AuthGuard } from "./auth.guard";
 import { LoginComponent } from "./pages/login/login.component";
 import { UserManagementComponent } from "./pages/user-manegement/user-manegement.component";
 import { DocumentVerificationComponent } from "./pages/document-verification/document-verification.component";
+import { DocumentVerificationDetailComponent } from "./pages/document-verification-detail/document-verification-detail.component";
 
 const routes: Routes = [
   { path: "login", component: LoginComponent },
@@ -20,10 +21,14 @@ const routes: Routes = [
         component: DocumentVerificationComponent,
       },
       {
+        path: "document-verification/:id",
+        component: DocumentVerificationDetailComponent,
+      },
+      {
         path: "forms",
         loadChildren: () =>
           import("./pages/esg-forms/esg-forms.module").then(
-            (m) => m.EsgFormsModule
+            (m) => m.EsgFormsModule,
           ),
       },
       { path: "", redirectTo: "/login", pathMatch: "full" },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -40,6 +40,7 @@ import { NgxDocViewerModule } from "ngx-doc-viewer";
 import { EsgFormsComponent } from "./pages/esg-forms/esg-forms.component";
 import { EsgFormsEditComponent } from "./pages/esg-forms/esg-forms-edit/esg-forms-edit.component";
 import { DocumentVerificationComponent } from "./pages/document-verification/document-verification.component";
+import { DocumentVerificationDetailComponent } from './pages/document-verification-detail/document-verification-detail.component';
 
 export function HttpLoaderFactory(http: HttpClient) {
   return new TranslateHttpLoader(http, "./assets/i18n/", ".json");
@@ -54,6 +55,7 @@ export function HttpLoaderFactory(http: HttpClient) {
     DashboardComponent,
     EsgFormsComponent,
     DocumentVerificationComponent,
+    DocumentVerificationDetailComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/interfaces/document-verification/question-row.interface.ts
+++ b/src/app/interfaces/document-verification/question-row.interface.ts
@@ -1,0 +1,6 @@
+export interface QuestionRow {
+  question: string;
+  answer: string;
+  document: string;
+  status: string;
+}

--- a/src/app/pages/document-verification-detail/document-verification-detail.component.html
+++ b/src/app/pages/document-verification-detail/document-verification-detail.component.html
@@ -1,0 +1,45 @@
+<div class="card-score">
+  <div class="card-score-info">
+    <div class="form-header">
+      <h2>Detalhes da verificação</h2>
+      <p>Informações da empresa e pontuação</p>
+    </div>
+  </div>
+  <div class="tabela-container">
+    <table mat-table [dataSource]="dataSource" class="full-width-table">
+      <ng-container matColumnDef="question">
+        <th mat-header-cell *matHeaderCellDef class="col-question">Questão</th>
+        <td mat-cell *matCellDef="let row">{{ row.question }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="answer">
+        <th mat-header-cell *matHeaderCellDef class="col-answer">Resposta</th>
+        <td mat-cell *matCellDef="let row">{{ row.answer }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="document">
+        <th mat-header-cell *matHeaderCellDef class="col-document">
+          Documento
+        </th>
+        <td mat-cell *matCellDef="let row">
+          <a [href]="row.document" target="_blank">PDF</a>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="status">
+        <th mat-header-cell *matHeaderCellDef class="col-status">Status</th>
+        <td mat-cell *matCellDef="let row">{{ row.status }}</td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+    <mat-paginator [pageSize]="10" showFirstLastButtons></mat-paginator>
+  </div>
+  <div class="actions">
+    <button mat-button routerLink="/document-verification">Voltar</button>
+    <button mat-raised-button color="primary" (click)="sendReview()">
+      Enviar revisão
+    </button>
+  </div>
+</div>

--- a/src/app/pages/document-verification-detail/document-verification-detail.component.scss
+++ b/src/app/pages/document-verification-detail/document-verification-detail.component.scss
@@ -1,0 +1,94 @@
+.card-score {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 24px;
+  background: #ffffff;
+  border: 1px solid #e1e6dd;
+  border-radius: 8px;
+  max-width: 1178px;
+  margin: 32px auto;
+
+  .card-score-info {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid #dadada;
+    padding-bottom: 16px;
+
+    .form-header {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+
+      h2 {
+        font-family: "Inter", sans-serif;
+        font-size: 24px;
+        font-weight: 700;
+        color: #222021;
+        margin: 0;
+      }
+
+      p {
+        font-size: 14px;
+        font-weight: 400;
+        color: rgba(0, 0, 0, 0.64);
+        margin: 0;
+      }
+    }
+  }
+
+  .tabela-container {
+    background: #fafaf8;
+    border: 1px solid #e1e6dd;
+    border-radius: 12px;
+    padding: 12px;
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+
+      th {
+        font-size: 12px;
+        font-weight: 700;
+        color: #222021;
+        padding: 14px 24px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        border-bottom: none;
+      }
+
+      td {
+        font-size: 14px;
+        font-weight: 500;
+        color: rgba(0, 0, 0, 0.64);
+        padding: 14px 24px;
+        border-bottom: none;
+      }
+    }
+
+    mat-paginator {
+      margin-top: 16px;
+    }
+  }
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 16px;
+  }
+
+  .col-question {
+    width: 30%;
+  }
+  .col-answer {
+    width: 30%;
+  }
+  .col-document {
+    width: 20%;
+  }
+  .col-status {
+    width: 20%;
+  }
+}

--- a/src/app/pages/document-verification-detail/document-verification-detail.component.spec.ts
+++ b/src/app/pages/document-verification-detail/document-verification-detail.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DocumentVerificationDetailComponent } from './document-verification-detail.component';
+
+describe('DocumentVerificationDetailComponent', () => {
+  let component: DocumentVerificationDetailComponent;
+  let fixture: ComponentFixture<DocumentVerificationDetailComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [DocumentVerificationDetailComponent]
+    });
+    fixture = TestBed.createComponent(DocumentVerificationDetailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/document-verification-detail/document-verification-detail.component.ts
+++ b/src/app/pages/document-verification-detail/document-verification-detail.component.ts
@@ -1,0 +1,41 @@
+import { Component, OnInit, AfterViewInit, ViewChild } from "@angular/core";
+import { ActivatedRoute } from "@angular/router";
+import { MatPaginator } from "@angular/material/paginator";
+import { MatTableDataSource } from "@angular/material/table";
+import { QuestionRow } from "src/app/interfaces/document-verification/question-row.interface";
+import { DocumentVerificationService } from "src/app/services/document-verification.service";
+
+@Component({
+  selector: "app-document-verification-detail",
+  templateUrl: "./document-verification-detail.component.html",
+  styleUrls: ["./document-verification-detail.component.scss"],
+})
+export class DocumentVerificationDetailComponent
+  implements OnInit, AfterViewInit
+{
+  displayedColumns: string[] = ["question", "answer", "document", "status"];
+  dataSource = new MatTableDataSource<QuestionRow>([]);
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
+
+  constructor(
+    private readonly route: ActivatedRoute,
+    private readonly service: DocumentVerificationService,
+  ) {}
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get("id");
+    if (id) {
+      this.service.get(id).subscribe((rows) => {
+        this.dataSource.data = rows;
+      });
+    }
+  }
+
+  ngAfterViewInit(): void {
+    this.dataSource.paginator = this.paginator;
+  }
+
+  sendReview(): void {
+    // TODO: implement review submission
+  }
+}

--- a/src/app/pages/document-verification/document-verification.component.html
+++ b/src/app/pages/document-verification/document-verification.component.html
@@ -67,8 +67,11 @@
 
       <ng-container matColumnDef="action">
         <th mat-header-cell *matHeaderCellDef class="col-actions">Ações</th>
-        <td mat-cell *matCellDef="let form">
-          <button mat-icon-button [routerLink]="['/forms/forms-new', form._id]">
+        <td mat-cell *matCellDef="let row">
+          <button
+            mat-icon-button
+            [routerLink]="['/document-verification', row.id]"
+          >
             <mat-icon>edit</mat-icon>
           </button>
         </td>

--- a/src/app/pages/document-verification/document-verification.component.ts
+++ b/src/app/pages/document-verification/document-verification.component.ts
@@ -15,7 +15,6 @@ import { FormInterface } from "src/app/interfaces/forms/form.interface";
   styleUrls: ["./document-verification.component.scss"],
 })
 export class DocumentVerificationComponent {
-}
   filteredList: any[] = [];
   loading = true;
   displayedColumns: string[] = [
@@ -25,25 +24,25 @@ export class DocumentVerificationComponent {
     "status",
     "action",
   ];
- dataSource = new MatTableDataSource<FormInterface>([]);
+  dataSource = new MatTableDataSource<FormInterface>([]);
 
-   @ViewChild(MatPaginator) paginator!: MatPaginator;
-   @ViewChild(MatSort) sort!: MatSort;
- 
-   constructor(
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
+
+  constructor(
     //  private _esgFormService: EsgFormService,
-     private spinnerService: NgxSpinnerService
-   ) {}
- 
-   ngAfterViewInit() {
-     this.dataSource.paginator = this.paginator;
-     this.dataSource.sort = this.sort;
-   }
- 
+    private spinnerService: NgxSpinnerService,
+  ) {}
+
+  ngAfterViewInit() {
+    this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
+  }
+
   //  ngOnInit(): void {
   //    this.updateEsgforms();
   //  }
- 
+
   //  updateEsgforms(): void {
   //    this.spinnerService.show();
   //    this._esgFormService
@@ -60,4 +59,4 @@ export class DocumentVerificationComponent {
   //        },
   //      });
   //  }
-  
+}

--- a/src/app/services/document-verification.service.ts
+++ b/src/app/services/document-verification.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from "@angular/core";
+import { HttpClient } from "@angular/common/http";
+import { Observable, catchError, map } from "rxjs";
+import { BaseService } from "./base.service";
+import { environment } from "src/environments/environment";
+import { QuestionRow } from "../interfaces/document-verification/question-row.interface";
+
+@Injectable({
+  providedIn: "root",
+})
+export class DocumentVerificationService extends BaseService {
+  private readonly url = `${environment.api.path}/document-verification`;
+
+  constructor(private readonly httpClient: HttpClient) {
+    super();
+  }
+
+  get(id: string): Observable<QuestionRow[]> {
+    return this.httpClient
+      .get(`${this.url}/${id}`, this.authorizedHeader())
+      .pipe(map(this.extractData), catchError(this.serviceError));
+  }
+}


### PR DESCRIPTION
## Summary
- add document verification detail component with table and actions
- wire document verification list to detail view
- stub service and interface for document verification

## Testing
- `npm test` *(fails: Chrome binary missing and spec compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f7bce76c832fbcf9117eebbc44cc